### PR TITLE
Remove Master-Edited file instructions and requirements

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,13 +18,11 @@ Currently, there are three possible scanners that can be used:
 
 A target from the Print Request option on Aeon should be created. This will be used as a citation sheet and should include Collection Name/Title, Record Group, Finding Aid number, Series, Box Number, Folder number and title, and date if available. **Be sure to check that the folder number/title on the citation sheet corresponds to the folder being scanned**.
 
-For PDF or TIFF/JPEG requests, scans should be saved into a folder titled with the researcher/donor’s name and transaction number on the X drive (X:\Projects\Reference Digitization). Within this folder, three sub-folders should be created: Master, Master Edited, and Service Edited. These three folders should be created for each folder scanned: 
+For PDF or TIFF/JPEG requests, scans should be saved into a folder titled with the researcher/donor’s name and transaction number on the X drive (X:\Projects\Reference Digitization). Within this folder, two sub-folders should be created: Master and Service Edited. These three folders should be created for each folder scanned: 
 
-**Master**: Uncompressed, high-resolution, original master files in TIFF format. Master files should not be edited or changed. 
+**Master**: Uncompressed, high-resolution, original master files in TIFF format. In the past, Master Edited files were created when images needed to be edited (de-skewed, cropped, etc.). However, since editing of every scanned image is rarely undertaken, creating Master edited files became redundant. Master files can be edited or changed if necessary.
 
-**Master Edited**: Uncompressed, high-resolution, edited copies of master files in which any cropping, color correction, or deskewing has been performed. This file should have the same resolution and file format as the Master file.
-
-**Service Edited**: Compressed, web-accessible, service file derived from the master edited file. For textual materials, service edited files should be in PDF format and for photographic materials, these files should be in JPEG format.
+**Service Edited**: Compressed, web-accessible, service file derived from the master TIF file. For textual materials, service edited files should be in PDF format and for photographic materials, these files should be in JPEG format.
 
 The scan resolution should be set to one of the following recommendations:  
 **Textual materials**: 300-400 dpi  
@@ -36,35 +34,30 @@ The scan resolution should be set to one of the following recommendations:
 Begin with the folder’s ref ID as a prefix. You can find this in the ArchivesSpace application or on the Aeon request (*if there is a Ref ID on Aeon be sure to double check that it is the correct Ref ID for the folder being scanned*). Each object in a folder should have the Ref ID, followed by an underscore, and then an escalating three-digit number for each scan in the folder.
 - Example: d47b6d80713746a4a91a2f0afee6fdea_001, d47b6d80713746a4a91a2f0afee6fdea_002
 
-Photographs with information on the reverse side should include reference to Verso or Recto in the filename. Recto is the front of the photograph, and verso is the back. Include “r” or “v” in the filename to designate what side we are viewing. If there is a recto, there has to be a file with a verso.
-- Example: c148d90fdb4dd3a2a3f6a891229d2720_001r c148d90fdb4dd3a2a3f6a891229d2720_001v
-
-Master edited and access should include “_me” for Master Edited or “_se” for Service Edited at the end of the file.
-
 #### Textual materials
 Master: 09bd143b788b4608b7fad28ac179922e_001.tif
-Master Edited: 09bd143b788b4608b7fad28ac179922e_001_me.tif  
-Service Edited: 09bd143b788b4608b7fad28ac179922e_se.pdf
+Service Edited: 09bd143b788b4608b7fad28ac179922e.pdf
 
 #### Photographic materials
-Master: b13ae3ee770c983cf869d77b17120689_001r.tif  
-Master Edited: b13ae3ee770c983cf869d77b17120689_001r_me.tif  
-Service Edited: b13ae3ee770c983cf869d77b17120689_001r_se.jpg
+Master: b13ae3ee770c983cf869d77b17120689_001.tif    
+Service Edited: b13ae3ee770c983cf869d77b17120689_001.jpg
 
 ### Quality Check and Creating Derivatives
-After scanning, copies of Master files should be inserted into the Master Edited folder (Master files should not be edited) and a quality check should be performed. This ensures that the digitized items accurately represent the original materials. When completing a quality check, you should make sure that:
+After scanning, a quality check should be performed on the Master files. This ensures that the digitized items accurately represent the original materials. When completing a quality check, you should make sure that:
 - Files are saved in the correct format
 - Files are saved in the correct location
 - The image count and file names are accurate
 - The images are not skewed or illegible
 - There are not any cropping issues
 
-Adobe Photoshop can be used to create derivative (Master Edited) files. **Remember that Master Edited files should end in “_me”**. 
+Adobe Photoshop can be used to edit files if necessary. 
 
-Service Edited files represent the form of the digitized TIFF files that researchers and/or donors will access. PDF and JPEG access files should always be derived from the Master Edited images. Adobe Photoshop can also be used to create JPEG access files. Adobe Acrobat DC can be used to create PDF access files. **Remember that Service Edited files should end in "_se"**. 
+Service Edited files represent the form of the digitized TIF files that researchers and/or donors will access. Adobe Photoshop can also be used to create JPEG access files. Adobe Acrobat DC can be used to create PDF access files. 
 
 ### Saving Files
-In the case of requests for researchers and donors, after the creation of the Service Edited files, a copy of the PDF or TIFF/JPEG should be saved on the W: drive. A folder labeled with the researcher’s/donor's name and transaction number (if applicable) should be created. A sub-folder entitled by the Aeon transaction number should then be created within this folder and the requested file  placed into this folder. 
+In the case of requests for researchers and donors, after the creation of the Service Edited files, a copy of the PDF or TIFF/JPEG should be saved on the W: drive. A folder labeled with the researcher’s/donor's name and transaction number (if applicable) should be created. A sub-folder entitled by the Aeon transaction number should then be created within this folder and the requested file placed into this folder. 
+
+Regardless of whether files are scanned for researcher, donor, or staff needs, all scanned folder level items in X:\Projects\Reference Digitization should be moved into X:\Projects\Reference Digitization\byRefId in a folder labeled with its RefID after scanning is completed. The RefID named folder must include Master and Service Edited named sub-folders and the corresponding files. 
 
 
 

--- a/index.md
+++ b/index.md
@@ -36,7 +36,6 @@ Begin with the folder’s ref ID as a prefix. You can find this in the ArchivesS
 
 #### Textual materials
 Master: 09bd143b788b4608b7fad28ac179922e_001.tif
-
 Service Edited: 09bd143b788b4608b7fad28ac179922e.pdf
 
 #### Photographic materials

--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ Begin with the folder’s ref ID as a prefix. You can find this in the ArchivesS
 - Example: d47b6d80713746a4a91a2f0afee6fdea_001, d47b6d80713746a4a91a2f0afee6fdea_002
 
 #### Textual materials
-Master: 09bd143b788b4608b7fad28ac179922e_001.tif
+Master: 09bd143b788b4608b7fad28ac179922e_001.tif     
 Service Edited: 09bd143b788b4608b7fad28ac179922e.pdf
 
 #### Photographic materials

--- a/index.md
+++ b/index.md
@@ -50,7 +50,7 @@ After scanning, a quality check should be performed on the Master files. This en
 - The images are not skewed or illegible
 - There are not any cropping issues
 
-Adobe Photoshop can be used to edit files if necessary. 
+Adobe Photoshop can be used to modify files if editing is necessary. 
 
 Service Edited files represent the form of the digitized TIF files that researchers and/or donors will access. Adobe Photoshop can also be used to create JPEG access files. Adobe Acrobat DC can be used to create PDF access files. 
 

--- a/index.md
+++ b/index.md
@@ -36,6 +36,7 @@ Begin with the folder’s ref ID as a prefix. You can find this in the ArchivesS
 
 #### Textual materials
 Master: 09bd143b788b4608b7fad28ac179922e_001.tif
+
 Service Edited: 09bd143b788b4608b7fad28ac179922e.pdf
 
 #### Photographic materials

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Currently, there are three possible scanners that can be used:
 
 A target from the Print Request option on Aeon should be created. This will be used as a citation sheet and should include Collection Name/Title, Record Group, Finding Aid number, Series, Box Number, Folder number and title, and date if available. **Be sure to check that the folder number/title on the citation sheet corresponds to the folder being scanned**.
 
-For PDF or TIFF/JPEG requests, scans should be saved into a folder titled with the researcher/donor’s name and transaction number on the X drive (X:\Projects\Reference Digitization). Within this folder, two sub-folders should be created: Master and Service Edited. These three folders should be created for each folder scanned: 
+For PDF or TIFF/JPEG requests, scans should be saved into a folder titled with the researcher/donor’s name and transaction number on the X drive (X:\Projects\Reference Digitization). Within this folder, two sub-folders should be created: Master and Service Edited. 
 
 **Master**: Uncompressed, high-resolution, original master files in TIFF format. In the past, Master Edited files were created when images needed to be edited (de-skewed, cropped, etc.). However, since editing of every scanned image is rarely undertaken, creating Master edited files became redundant. Master files can be edited or changed if necessary.
 


### PR DESCRIPTION
Removes instructions and requirements related to Master-Edited files, which are no longer part of the RAC's digitization practice.